### PR TITLE
ignore .factorypath (eclipse)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .classpath
 .project
 .settings/
+.factorypath
 
 # Intellij
 .idea/


### PR DESCRIPTION
Seems to be generated by vscode with java/maven support and otherwise
ignored as well:
https://github.com/github/gitignore/blob/7ab549fcae8269fdd4004065470176f829d88200/Global/Eclipse.gitignore#L28-L29