### PR TITLE
Add jaxws-ri as a dependency

### DIFF
--- a/mod-erm-usage-harvester-cs41/pom.xml
+++ b/mod-erm-usage-harvester-cs41/pom.xml
@@ -41,6 +41,12 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.sun.xml.ws</groupId>
+      <artifactId>jaxws-ri</artifactId>
+      <version>2.3.3</version>
+      <type>pom</type>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
`javax.xml.ws.*` was deprecated in Java 9 and finally removed in Java 11. However, `CS41Impl.java` imports and uses `javax.xml.ws.BindingProvider`. Thus, to be able to start the module I had to add the dependency `jaxws-ri`.