### PR TITLE
MODEUSHARV-30

### DIFF
--- a/mod-erm-usage-harvester-core/src/main/java/org/olf/erm/usage/harvester/ExceptionUtil.java
+++ b/mod-erm-usage-harvester-core/src/main/java/org/olf/erm/usage/harvester/ExceptionUtil.java
@@ -1,0 +1,10 @@
+package org.olf.erm.usage.harvester;
+
+public class ExceptionUtil {
+
+  private ExceptionUtil() {}
+
+  public static String getMessageOrToString(Throwable t) {
+    return (t.getMessage() != null) ? t.getMessage() : t.toString();
+  }
+}

--- a/mod-erm-usage-harvester-core/src/main/java/org/olf/erm/usage/harvester/WorkerVerticle.java
+++ b/mod-erm-usage-harvester-core/src/main/java/org/olf/erm/usage/harvester/WorkerVerticle.java
@@ -1,5 +1,6 @@
 package org.olf.erm.usage.harvester;
 
+import static org.olf.erm.usage.harvester.ExceptionUtil.getMessageOrToString;
 import static org.olf.erm.usage.harvester.Messages.createErrMsgDecode;
 import static org.olf.erm.usage.harvester.Messages.createMsgStatus;
 import static org.olf.erm.usage.harvester.Messages.createProviderMsg;
@@ -424,7 +425,7 @@ public class WorkerVerticle extends AbstractVerticle {
                                   token.getTenantId(),
                                   provider.getLabel(),
                                   "received {}",
-                                  t.getMessage()));
+                                  getMessageOrToString(t)));
                           if (!(t instanceof InvalidReportException)) {
                             // handle generic failues
                             List<CounterReport> counterReportList =
@@ -434,7 +435,7 @@ public class WorkerVerticle extends AbstractVerticle {
                                         ym ->
                                             createCounterReport(
                                                     null, fetchItem.getReportType(), provider, ym)
-                                                .withFailedReason(t.getMessage()))
+                                                .withFailedReason(getMessageOrToString(t)))
                                     .collect(Collectors.toList());
                             return Observable.just(counterReportList);
                           }
@@ -454,7 +455,7 @@ public class WorkerVerticle extends AbstractVerticle {
                                             fetchItem.getReportType(),
                                             provider,
                                             DateUtil.getYearMonthFromString(fetchItem.getBegin()))
-                                        .withFailedReason(t.getMessage())));
+                                        .withFailedReason(getMessageOrToString(t))));
                           } else {
                             // handle failes multiple months
                             logInfo(

--- a/mod-erm-usage-harvester-core/src/main/java/org/olf/erm/usage/harvester/WorkerVerticle.java
+++ b/mod-erm-usage-harvester-core/src/main/java/org/olf/erm/usage/harvester/WorkerVerticle.java
@@ -479,7 +479,11 @@ public class WorkerVerticle extends AbstractVerticle {
         () -> createTenantMsg(token.getTenantId(), "processing provider: {}", provider.getLabel()));
 
     wrapFuture(updateUDPLastHarvestingDate(provider))
-        .doOnError(t -> LOG.error(t.getMessage()))
+        .doOnError(
+            t ->
+                logError(
+                    createTenantProviderMsg(
+                        token.getTenantId(), provider.getLabel(), "{}", t.getMessage())))
         .ignoreElement()
         .onErrorComplete()
         .subscribe();
@@ -512,12 +516,26 @@ public class WorkerVerticle extends AbstractVerticle {
             })
         .flatMapObservable(listObservable -> listObservable)
         .flatMap(Observable::fromIterable)
-        .doOnNext(cr -> LOG.info("Received: {}", counterReportToString(cr)))
+        .doOnNext(
+            cr ->
+                logInfo(
+                    createTenantProviderMsg(
+                        token.getTenantId(),
+                        provider.getLabel(),
+                        "Received: {}",
+                        counterReportToString(cr))))
         .flatMapCompletable(
             cr ->
                 wrapFuture(postReport(cr))
                     .ignoreElement()
-                    .doOnError(t -> LOG.error(t.getMessage()))
+                    .doOnError(
+                        t ->
+                            logError(
+                                createTenantProviderMsg(
+                                    token.getTenantId(),
+                                    provider.getLabel(),
+                                    "{}",
+                                    t.getMessage())))
                     .onErrorComplete());
   }
 

--- a/mod-erm-usage-harvester-core/src/main/java/org/olf/erm/usage/harvester/WorkerVerticle.java
+++ b/mod-erm-usage-harvester-core/src/main/java/org/olf/erm/usage/harvester/WorkerVerticle.java
@@ -665,7 +665,7 @@ public class WorkerVerticle extends AbstractVerticle {
               if (resp.statusCode() == 200) {
                 return resp.bodyAsJson(UsageDataProvider.class);
               } else {
-                throw new Exception(
+                throw new WorkerVerticleException(
                     createProviderMsg(
                         providerId,
                         createMsgStatus(resp.statusCode(), resp.statusMessage(), providerPath)));
@@ -676,7 +676,7 @@ public class WorkerVerticle extends AbstractVerticle {
               if (udp.getHarvestingConfig().getHarvestingStatus().equals(HarvestingStatus.ACTIVE)) {
                 return udp;
               } else {
-                throw new Exception(
+                throw new WorkerVerticleException(
                     createProviderMsg(udp.getLabel(), "HarvestingStatus not ACTIVE"));
               }
             })
@@ -800,5 +800,12 @@ public class WorkerVerticle extends AbstractVerticle {
               }
             });
     return promise.future();
+  }
+
+  public static class WorkerVerticleException extends Exception {
+
+    public WorkerVerticleException(String message) {
+      super(message);
+    }
   }
 }

--- a/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/ExceptionUtilTest.java
+++ b/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/ExceptionUtilTest.java
@@ -1,0 +1,17 @@
+package org.olf.erm.usage.harvester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.olf.erm.usage.harvester.ExceptionUtil.getMessageOrToString;
+
+import org.junit.Test;
+
+public class ExceptionUtilTest {
+
+  @Test
+  public void testGetMessageOrToString() {
+    Exception e1 = new Exception("test");
+    Exception e2 = new Exception();
+    assertThat(getMessageOrToString(e1)).isEqualTo("test");
+    assertThat(getMessageOrToString(e2)).isEqualTo("java.lang.Exception");
+  }
+}

--- a/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/endpoints/WorkerVerticleITProviderFailsWithGetMessageNull.java
+++ b/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/endpoints/WorkerVerticleITProviderFailsWithGetMessageNull.java
@@ -1,0 +1,44 @@
+package org.olf.erm.usage.harvester.endpoints;
+
+import io.vertx.core.Future;
+import java.util.List;
+import org.folio.rest.jaxrs.model.AggregatorSetting;
+import org.folio.rest.jaxrs.model.CounterReport;
+import org.folio.rest.jaxrs.model.UsageDataProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WorkerVerticleITProviderFailsWithGetMessageNull implements ServiceEndpointProvider {
+
+  @Override
+  public String getServiceType() {
+    return "wvitpfail";
+  }
+
+  @Override
+  public String getServiceName() {
+    return "WorkerVerticleITProviderFailsWithGetMessageNull";
+  }
+
+  @Override
+  public String getServiceDescription() {
+    return "Test Provider fails with java.lang.Exception.getMessage() == null";
+  }
+
+  @Override
+  public ServiceEndpoint create(UsageDataProvider provider, AggregatorSetting aggregator) {
+
+    return new ServiceEndpoint() {
+      private final Logger log =
+          LoggerFactory.getLogger(WorkerVerticleITProviderFailsWithGetMessageNull.class);
+
+      @Override
+      public Future<List<CounterReport>> fetchReport(
+          String report, String beginDate, String endDate) {
+        log.info("Fetching report {} {} {}", report, beginDate, endDate);
+
+        return Future.failedFuture(new Exception());
+      }
+    };
+  }
+}

--- a/mod-erm-usage-harvester-core/src/test/resources/META-INF/services/org.olf.erm.usage.harvester.endpoints.ServiceEndpointProvider
+++ b/mod-erm-usage-harvester-core/src/test/resources/META-INF/services/org.olf.erm.usage.harvester.endpoints.ServiceEndpointProvider
@@ -3,3 +3,4 @@ org.olf.erm.usage.harvester.endpoints.Test2Provider
 org.olf.erm.usage.harvester.endpoints.WorkerVerticleITProvider
 org.olf.erm.usage.harvester.endpoints.WorkerVerticleITProvider2
 org.olf.erm.usage.harvester.endpoints.WorkerVerticleITProvider3
+org.olf.erm.usage.harvester.endpoints.WorkerVerticleITProviderFailsWithGetMessageNull


### PR DESCRIPTION
When harvesting fails with an Exception e, e.getMessage() is added to the resulting report as 'failedReason'.
e.getMessage() can be null sometimes, which results in a missing 'failedReason' attribute.
This PR solves the issue by using e.toString() as 'failedReason' in case e.getMessage() should be null.
A test case is included.

Additionally this PR updates the formatting of some log messages and adds a WorkerVerticleException which is thrown instead of a generic Exception.