### PR TITLE
MODEUSHARV-29

### DIFF
--- a/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/endpoints/WorkerVerticleITProviderFailsInitialization.java
+++ b/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/endpoints/WorkerVerticleITProviderFailsInitialization.java
@@ -1,0 +1,27 @@
+package org.olf.erm.usage.harvester.endpoints;
+
+import org.folio.rest.jaxrs.model.AggregatorSetting;
+import org.folio.rest.jaxrs.model.UsageDataProvider;
+
+public class WorkerVerticleITProviderFailsInitialization implements ServiceEndpointProvider {
+
+  @Override
+  public String getServiceType() {
+    return "wvitpfailinit";
+  }
+
+  @Override
+  public String getServiceName() {
+    return "WorkerVerticleITProviderFailsInitialization";
+  }
+
+  @Override
+  public String getServiceDescription() {
+    return "Test Provider fails to initialize";
+  }
+
+  @Override
+  public ServiceEndpoint create(UsageDataProvider provider, AggregatorSetting aggregator) {
+    throw new RuntimeException("Initialization error");
+  }
+}

--- a/mod-erm-usage-harvester-core/src/test/resources/META-INF/services/org.olf.erm.usage.harvester.endpoints.ServiceEndpointProvider
+++ b/mod-erm-usage-harvester-core/src/test/resources/META-INF/services/org.olf.erm.usage.harvester.endpoints.ServiceEndpointProvider
@@ -4,3 +4,4 @@ org.olf.erm.usage.harvester.endpoints.WorkerVerticleITProvider
 org.olf.erm.usage.harvester.endpoints.WorkerVerticleITProvider2
 org.olf.erm.usage.harvester.endpoints.WorkerVerticleITProvider3
 org.olf.erm.usage.harvester.endpoints.WorkerVerticleITProviderFailsWithGetMessageNull
+org.olf.erm.usage.harvester.endpoints.WorkerVerticleITProviderFailsInitialization


### PR DESCRIPTION
A `ServiceEndpoint` can fail to initialize properly. This is for instance the case if you provide a invalid service url (e.g. without proper protocol) for CS50Impl. In this case no reports are created.

This PR changes the harvesting behavior so that in these cases, reports are still created. The created reports will be marked as failed and failedReason will contain the exception that was thrown during `ServiceEndpoint` initialization.