### PR TITLE
MODEUSHARV-32

### DIFF
--- a/mod-erm-usage-harvester-cs50/src/test/java/org/olf/erm/usage/harvester/endpoints/CS50ImplTest.java
+++ b/mod-erm-usage-harvester-cs50/src/test/java/org/olf/erm/usage/harvester/endpoints/CS50ImplTest.java
@@ -197,6 +197,28 @@ public class CS50ImplTest {
   }
 
   @Test
+  public void testFetchReportWithException(TestContext context) throws IOException {
+    String reportStr =
+        Resources.toString(
+            Resources.getResource("SampleReportExceptionError.json"), StandardCharsets.UTF_8);
+    wmRule.stubFor(
+        get(urlPathEqualTo(REPORT_PATH))
+            .willReturn(aResponse().withStatus(200).withBody(reportStr)));
+
+    new CS50Impl(provider)
+        .fetchReport(REPORT, BEGIN_DATE, END_DATE)
+        .onComplete(
+            context.asyncAssertFailure(
+                t -> {
+                  System.out.println(t.toString());
+                  assertThat(t)
+                      .isInstanceOf(InvalidReportException.class)
+                      .hasMessageContaining("Invalid Customer Id");
+                  verifyApiCall();
+                }));
+  }
+
+  @Test
   public void testFetchReportOkWithStatus200(TestContext context) throws IOException {
     String expectedReportStr =
         Resources.toString(Resources.getResource("SampleReport.json"), StandardCharsets.UTF_8);

--- a/mod-erm-usage-harvester-cs50/src/test/java/org/olf/erm/usage/harvester/endpoints/CS50ImplTest.java
+++ b/mod-erm-usage-harvester-cs50/src/test/java/org/olf/erm/usage/harvester/endpoints/CS50ImplTest.java
@@ -134,17 +134,64 @@ public class CS50ImplTest {
   }
 
   @Test
-  public void testFetchReportNoHeader(TestContext context) {
-    String cr = gson.toJson(new COUNTERTitleReport());
+  public void testFetchReportNoHeader(TestContext context) throws IOException {
+    String reportStr =
+        Resources.toString(
+            Resources.getResource("SampleReportMissingHeader.json"), StandardCharsets.UTF_8);
     wmRule.stubFor(
-        get(urlPathEqualTo(REPORT_PATH)).willReturn(aResponse().withStatus(200).withBody(cr)));
+        get(urlPathEqualTo(REPORT_PATH))
+            .willReturn(aResponse().withStatus(200).withBody(reportStr)));
 
     new CS50Impl(provider)
         .fetchReport(REPORT, BEGIN_DATE, END_DATE)
         .onComplete(
             context.asyncAssertFailure(
                 t -> {
-                  assertThat(t).hasMessageContaining("missing reportHeader");
+                  assertThat(t)
+                      .isInstanceOf(InvalidReportException.class)
+                      .hasMessageContaining("missing Report_Header");
+                  verifyApiCall();
+                }));
+  }
+
+  @Test
+  public void testFetchReportMissingReportItems(TestContext context) throws IOException {
+    String reportStr =
+        Resources.toString(
+            Resources.getResource("SampleReportMissingItems.json"), StandardCharsets.UTF_8);
+    wmRule.stubFor(
+        get(urlPathEqualTo(REPORT_PATH))
+            .willReturn(aResponse().withStatus(200).withBody(reportStr)));
+
+    new CS50Impl(provider)
+        .fetchReport(REPORT, BEGIN_DATE, END_DATE)
+        .onComplete(
+            context.asyncAssertFailure(
+                t -> {
+                  assertThat(t)
+                      .isInstanceOf(InvalidReportException.class)
+                      .hasMessageContaining("missing Report_Items");
+                  verifyApiCall();
+                }));
+  }
+
+  @Test
+  public void testFetchReportEmptyReportItems(TestContext context) throws IOException {
+    String reportStr =
+        Resources.toString(
+            Resources.getResource("SampleReportEmptyItems.json"), StandardCharsets.UTF_8);
+    wmRule.stubFor(
+        get(urlPathEqualTo(REPORT_PATH))
+            .willReturn(aResponse().withStatus(200).withBody(reportStr)));
+
+    new CS50Impl(provider)
+        .fetchReport(REPORT, BEGIN_DATE, END_DATE)
+        .onComplete(
+            context.asyncAssertFailure(
+                t -> {
+                  assertThat(t)
+                      .isInstanceOf(InvalidReportException.class)
+                      .hasMessageContaining("missing Report_Items");
                   verifyApiCall();
                 }));
   }

--- a/mod-erm-usage-harvester-cs50/src/test/resources/SampleReportExceptionError.json
+++ b/mod-erm-usage-harvester-cs50/src/test/resources/SampleReportExceptionError.json
@@ -1,0 +1,55 @@
+{
+  "Report_Header": {
+    "Created": "2020-11-30T09:47:31-08:00",
+    "Created_By": "HighWire Press Inc.",
+    "Report_ID": "TR_J1",
+    "Release": "5",
+    "Report_Name": "Journal Requests (Excluding OA_Gold)",
+    "Institution_Name": "instName",
+    "Institution_ID": [
+      {
+        "Type": "Proprietary",
+        "Value": "HighWire:custId"
+      }
+    ],
+    "Report_Filters": [
+      {
+        "Name": "Begin_Date",
+        "Value": "2018-10-01"
+      },
+      {
+        "Name": "End_Date",
+        "Value": "2018-10-31"
+      },
+      {
+        "Name": "Metric_Type",
+        "Value": "Total_Item_Requests"
+      },
+      {
+        "Name": "Metric_Type",
+        "Value": "Unique_Item_Requests"
+      },
+      {
+        "Name": "Access_Type",
+        "Value": "Controlled"
+      },
+      {
+        "Name": "Data_Type",
+        "Value": "Journal"
+      },
+      {
+        "Name": "Access_Method",
+        "Value": "Regular"
+      }
+    ],
+    "Report_Attributes": [],
+    "Exceptions": [
+      {
+        "Message": "Invalid Customer Id",
+        "Severity": "Fatal",
+        "Code": 1030
+      }
+    ]
+  },
+  "Report_Items": []
+}


### PR DESCRIPTION
This PR adds an additional check for received Counter5 reports, so that reports without `Report_Items` will throw a `InvalidReportException`.