### PR TITLE
MODEUSHARV-78: Hazelcast 4.2.6, Vert.x 4.3.7, RMB 35.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
 
-    <raml-module-builder.version>35.0.1</raml-module-builder.version>
+    <raml-module-builder.version>35.0.4</raml-module-builder.version>
     <ramlfiles_path>${project.basedir}/ramls</ramlfiles_path>
-    <vertx.version>4.3.4</vertx.version>
+    <vertx.version>4.3.7</vertx.version>
     <erm.usage.version>4.3.0</erm.usage.version>
     <erm.usage.counter.version>2.2.5</erm.usage.counter.version>
     <configurations.version>5.7.5</configurations.version>


### PR DESCRIPTION
Upgrade Vert.x from 4.3.4 to 4.3.7, this indirectly upgrades hazelcast from 4.2.2 to 4.2.6 fixing improper authentication:

https://nvd.nist.gov/vuln/detail/CVE-2022-36437

To match the Vert.x version:

Upgrade RMB from 35.0.1 to 35.0.4.