### PR TITLE
MODEUSHARV-81

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-erm-usage-harvester
 
-Copyright (C) 2018-2022 The Open Library Foundation
+Copyright (C) 2018-2023 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License, Version 2.0. See the
 file "[LICENSE](LICENSE)" for more information.
@@ -219,13 +219,12 @@ client expects `2xx` codes to return counter reports and different codes to retu
 So if reponses with status code `2xx` are received, it is checked whether the response data
 structure matches one of the 4 counter master reports (`TR`, `PR`, `DR` and `IR`). If it does match,
 no changes are made to the response. If it does not match, the response gets transformed into
-a `400 - Bad Request` response, preserving the original response body.
+a `400 - Bad Request` response, preserving the original response body in cases listed below.
 
 Some observations and how they are handled so far:
 
-* Providers use `2xx` status codes to return sushi errors (everything thats not a report gets routed
-  to and handled as `400`)
-* Providers return sushi errors as array instead of object (array makes it into the error message)
+* Providers use `2xx` status codes to return sushi errors, not reports (gets routed and handled as `400` with original response body)
+* Providers return sushi errors as array instead of object (array makes it into the response body)
 * Providers return `"null"` instead of sushi error (returns a `InvalidReportException: null`)
 * Providers return reports with a `Report_Header` that contains a `Exception` object instead of
   a `Exceptions` array (not handled, will be interpreted as report without `Exceptions`)

--- a/mod-erm-usage-harvester-cs50/src/main/java/org/olf/erm/usage/harvester/endpoints/DefaultApi.java
+++ b/mod-erm-usage-harvester-cs50/src/main/java/org/olf/erm/usage/harvester/endpoints/DefaultApi.java
@@ -1,49 +1,17 @@
 package org.olf.erm.usage.harvester.endpoints;
 
 import io.reactivex.Observable;
-import java.util.List;
 import org.openapitools.client.model.COUNTERDatabaseReport;
 import org.openapitools.client.model.COUNTERItemReport;
 import org.openapitools.client.model.COUNTERPlatformReport;
 import org.openapitools.client.model.COUNTERTitleReport;
-import org.openapitools.client.model.SUSHIConsortiumMemberList;
-import org.openapitools.client.model.SUSHIReportList;
-import org.openapitools.client.model.SUSHIServiceStatus;
 import retrofit2.http.GET;
 import retrofit2.http.Query;
 
 public interface DefaultApi {
 
-  @GET("status")
-  Observable<List<SUSHIServiceStatus>> getAPIStatus(
-      @Query("customer_id") String customerId, @Query("platform") String platform);
-
-  @GET("members")
-  Observable<List<SUSHIConsortiumMemberList>> getConsortiumMembers(
-      @Query("customer_id") String customerId, @Query("platform") String platform);
-
-  @GET("reports")
-  Observable<List<SUSHIReportList>> getReports(
-      @Query("customer_id") String customerId,
-      @Query("platform") String platform,
-      @Query("search") String search);
-
   @GET("reports/dr?attributes_to_show=Data_Type|Access_Method")
   Observable<COUNTERDatabaseReport> getReportsDR(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-
-  @GET("reports/dr_d1")
-  Observable<COUNTERDatabaseReport> getReportsDRD1(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-
-  @GET("reports/dr_d2")
-  Observable<COUNTERDatabaseReport> getReportsDRD2(
       @Query("customer_id") String customerId,
       @Query("begin_date") String beginDate,
       @Query("end_date") String endDate,
@@ -58,20 +26,6 @@ public interface DefaultApi {
       @Query("end_date") String endDate,
       @Query("platform") String platform);
 
-  @GET("reports/ir_a1")
-  Observable<COUNTERItemReport> getReportsIRA1(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-
-  @GET("reports/ir_m1")
-  Observable<COUNTERItemReport> getReportsIRM1(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-
   @GET("reports/pr?attributes_to_show=Data_Type|Access_Method")
   Observable<COUNTERPlatformReport> getReportsPR(
       @Query("customer_id") String customerId,
@@ -79,65 +33,8 @@ public interface DefaultApi {
       @Query("end_date") String endDate,
       @Query("platform") String platform);
 
-  @GET("reports/pr_p1")
-  Observable<COUNTERPlatformReport> getReportsPRP1(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-
   @GET("reports/tr?attributes_to_show=Data_Type|Section_Type|YOP|Access_Type|Access_Method")
   Observable<COUNTERTitleReport> getReportsTR(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-  // @Query("data_type") String dataType);
-
-  @GET("reports/tr_b1")
-  Observable<COUNTERTitleReport> getReportsTRB1(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-
-  @GET("reports/tr_b2")
-  Observable<COUNTERTitleReport> getReportsTRB2(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-
-  @GET("reports/tr_b3")
-  Observable<COUNTERTitleReport> getReportsTRB3(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-
-  @GET("reports/tr_j1")
-  Observable<COUNTERTitleReport> getReportsTRJ1(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-
-  @GET("reports/tr_j2")
-  Observable<COUNTERTitleReport> getReportsTRJ2(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-
-  @GET("reports/tr_j3")
-  Observable<COUNTERTitleReport> getReportsTRJ3(
-      @Query("customer_id") String customerId,
-      @Query("begin_date") String beginDate,
-      @Query("end_date") String endDate,
-      @Query("platform") String platform);
-
-  @GET("reports/tr_j4")
-  Observable<COUNTERTitleReport> getReportsTRJ4(
       @Query("customer_id") String customerId,
       @Query("begin_date") String beginDate,
       @Query("end_date") String endDate,

--- a/mod-erm-usage-harvester-cs50/src/main/java/org/olf/erm/usage/harvester/endpoints/JsonUtil.java
+++ b/mod-erm-usage-harvester-cs50/src/main/java/org/olf/erm/usage/harvester/endpoints/JsonUtil.java
@@ -1,5 +1,6 @@
 package org.olf.erm.usage.harvester.endpoints;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,5 +34,9 @@ public class JsonUtil {
     } catch (Exception e) {
       return false;
     }
+  }
+
+  public static void validate(String json, Class<?> clazz) throws JsonProcessingException {
+    om.readValue(json, clazz);
   }
 }


### PR DESCRIPTION
* If report deserialization fails replace the response body with the deserialization error message. In special cases, like when receiving a SUSHIErrorModel, keep the original response body.
* Try to deserialize responses into the expected report class only (e.g. when receiving a response from /reports/tr.. we are expecting a COUNTERTitleReport)
* Get rid of unused methods in the DefaultApi interface