### PR TITLE
EUREKA-288 Disable system user login via environment variable

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -300,6 +300,11 @@
         "description": "Okapi URL"
       },
       {
+        "name": "SYSTEM_USER_ENABLED",
+        "value": "true",
+        "description": "Defines if system user login call is enabled or not (true if not defined)"
+      },
+      {
         "name": "DIKU_USER_NAME",
         "value": "mod-erm-usage-harvester",
         "description": "System user username for tenant diku"

--- a/mod-erm-usage-harvester-core/src/main/java/org/olf/erm/usage/harvester/periodic/HarvestTenantPeriodicJob.java
+++ b/mod-erm-usage-harvester-core/src/main/java/org/olf/erm/usage/harvester/periodic/HarvestTenantPeriodicJob.java
@@ -2,6 +2,7 @@ package org.olf.erm.usage.harvester.periodic;
 
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
+import static java.lang.Boolean.parseBoolean;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -51,8 +52,7 @@ public class HarvestTenantPeriodicJob extends AbstractHarvestJob {
     OkapiClient okapiClient = new OkapiClientImpl(webClient, vertxContext.config());
 
     CompletableFuture<Void> complete =
-        okapiClient
-            .loginSystemUser(getTenantId(), new SystemUser(getTenantId()))
+        loginSystemUserIfEnabled(okapiClient, getTenantId())
             .compose(token -> okapiClient.startHarvester(getTenantId(), token))
             .<Void>compose(
                 resp -> {
@@ -87,5 +87,9 @@ public class HarvestTenantPeriodicJob extends AbstractHarvestJob {
       throw new JobExecutionException(
           String.format("Tenant: %s, error starting harvester: %s", getTenantId(), e.getMessage()));
     }
+  }
+
+  private Future<String> loginSystemUserIfEnabled(OkapiClient okapiClient, String tenantId) {
+    return okapiClient.loginSystemUser(tenantId, new SystemUser(tenantId));
   }
 }

--- a/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/client/OkapiClientImplTest.java
+++ b/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/client/OkapiClientImplTest.java
@@ -90,6 +90,15 @@ public class OkapiClientImplTest {
   }
 
   @Test
+  public void testLegacyLoginSystemUserDisabled(TestContext context) {
+    String okapiUrl = StringUtils.removeEnd(wireMockRule.url(""), "/");
+    okapiClient = new OkapiClientImpl(WebClient.create(vertx), okapiUrl, false);
+    okapiClient
+      .loginSystemUser(tenantId, SYSTEM_USER)
+      .onComplete(context.asyncAssertSuccess(s -> assertThat(s).isNull()));
+  }
+
+  @Test
   public void testLoginWithExpiryInvalidCookie(TestContext context) {
     stubFor(
         post(urlEqualTo(PATH_LOGIN_EXPIRY))


### PR DESCRIPTION
### Purpose

This PR allows DevOps team to disable the system user login call if this module is deployed within the sidecar (which takes responsibility for authorizing egress requests for modules)

### Approach

- Using the system variable `SYSTEM_USER_ENABLED` define if a login call must be performed or not
- Add unit test to verify this behavior