### PR TITLE
EUREKA-288 Add system user section

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -242,6 +242,14 @@
       ]
     }
   ],
+  "metadata": {
+    "user": {
+      "type": "system",
+      "permissions": [
+        "ermusageharvester.start.single"
+      ]
+    }
+  },
   "launchDescriptor": {
     "dockerImage": "${project.artifactId}:${project.version}",
     "dockerPull": false,


### PR DESCRIPTION
### Purpose

Adds a system user section to define optional system user in `ModuleDescriptor-template.json`
Permission name is used instead of a permission-set name because system users can be created in `mod-users-keycloak` using only capabilities (sourced from plain permissions).

### Approach

- Add `metadata` section with system user descriptor to `ModuleDescriptor-template.json`