### PR TITLE
MODEUSHARV-111 Update to usage-data-providers 3.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -158,7 +158,7 @@
   "requires": [
     {
       "id": "usage-data-providers",
-      "version": "2.5"
+      "version": "3.0"
     },
     {
       "id": "aggregator-settings",

--- a/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/HarvestingIT.java
+++ b/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/HarvestingIT.java
@@ -127,7 +127,7 @@ public class HarvestingIT {
             .withHarvestingConfig(
                 new HarvestingConfig()
                     .withRequestedReports(List.of("JR1"))
-                    .withReportRelease(4)
+                    .withReportRelease("4")
                     .withHarvestingStart("2018-01")
                     .withHarvestingEnd("2020-04")
                     .withHarvestingStatus(HarvestingStatus.ACTIVE)
@@ -148,7 +148,7 @@ public class HarvestingIT {
             .withHarvestingConfig(
                 new HarvestingConfig()
                     .withRequestedReports(List.of("JR1"))
-                    .withReportRelease(4)
+                    .withReportRelease("4")
                     .withHarvestingStart("2018-01")
                     .withHarvestingEnd("2020-04")
                     .withHarvestingStatus(HarvestingStatus.ACTIVE)
@@ -646,7 +646,7 @@ public class HarvestingIT {
   public void testFailedUploadsMax(TestContext context) {
     UsageDataProvider usageDataProvider = tenantUDPMap.get(TENANTA).get(0);
     usageDataProvider.getHarvestingConfig().setRequestedReports(List.of("TR"));
-    usageDataProvider.getHarvestingConfig().setReportRelease(5);
+    usageDataProvider.getHarvestingConfig().setReportRelease("5");
     usageDataProvider.getHarvestingConfig().setHarvestingStart("2018-01");
     usageDataProvider.getHarvestingConfig().setHarvestingEnd("2018-12");
 
@@ -752,7 +752,7 @@ public class HarvestingIT {
     harvestingConfig.getSushiConfig().setServiceType("wvitpfailinit");
     harvestingConfig
         .withRequestedReports(List.of("TR"))
-        .withReportRelease(5)
+        .withReportRelease("5")
         .withHarvestingStart("2021-01")
         .withHarvestingEnd("2021-03");
 
@@ -835,7 +835,7 @@ public class HarvestingIT {
               harvestingConfig.getSushiConfig().setServiceType("wvitpfail");
               harvestingConfig
                   .withRequestedReports(List.of("TR"))
-                  .withReportRelease(5)
+                  .withReportRelease("5")
                   .withHarvestingStart("2021-01")
                   .withHarvestingEnd("2021-01");
             });

--- a/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/TestUtil.java
+++ b/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/TestUtil.java
@@ -34,7 +34,7 @@ public class TestUtil {
                 .withHarvestingStatus(HarvestingStatus.ACTIVE)
                 .withHarvestVia(HarvestVia.SUSHI)
                 .withSushiConfig(new SushiConfig().withServiceType("test1"))
-                .withReportRelease(4)
+                .withReportRelease("4")
                 .withHarvestingStart("2017-12")
                 .withHarvestingEnd("2018-04")
                 .withRequestedReports(Arrays.asList("JR1", "JR2", "JR3")));

--- a/mod-erm-usage-harvester-core/src/test/resources/__files/usage-data-provider.json
+++ b/mod-erm-usage-harvester-core/src/test/resources/__files/usage-data-provider.json
@@ -12,7 +12,7 @@
       "id": "4c66b956-23a8-4418-aef6-1c35dcdaccc4",
       "vendorCode": "ACMDL"
     },
-    "reportRelease": 4,
+    "reportRelease": "4",
     "requestedReports": [
       "JR1",
       "TR1"

--- a/mod-erm-usage-harvester-core/src/test/resources/__files/usage-data-providers.json
+++ b/mod-erm-usage-harvester-core/src/test/resources/__files/usage-data-providers.json
@@ -14,7 +14,7 @@
           "id": "4c66b956-23a8-4418-aef6-1c35dcdaccc4",
           "vendorCode": "ACMDL"
         },
-        "reportRelease": 4,
+        "reportRelease": "4",
         "requestedReports": [
           "JR1",
           "TR1"
@@ -41,7 +41,7 @@
           "serviceType": "cs41",
           "serviceUrl": "http://myvendor.com"
         },
-        "reportRelease": 4,
+        "reportRelease": "4",
         "requestedReports": [
           "JR1",
           "TR1"
@@ -72,7 +72,7 @@
           "id": "4c66b956-23a8-4418-aef6-1c35dcdaccc4",
           "vendorCode": "ACMDL"
         },
-        "reportRelease": 4,
+        "reportRelease": "4",
         "requestedReports": [
           "JR1",
           "TR1"

--- a/mod-erm-usage-harvester-cs41/src/test/java/org/olf/erm/usage/harvester/endpoints/CS41ImplTest.java
+++ b/mod-erm-usage-harvester-cs41/src/test/java/org/olf/erm/usage/harvester/endpoints/CS41ImplTest.java
@@ -55,7 +55,7 @@ public class CS41ImplTest {
       new UsageDataProvider()
           .withId("67339c41-a3a7-4d19-83e2-c808ab99c8fe")
           .withHarvestingConfig(
-              new HarvestingConfig().withReportRelease(4).withSushiConfig(new SushiConfig()))
+              new HarvestingConfig().withReportRelease("4").withSushiConfig(new SushiConfig()))
           .withSushiCredentials(
               new SushiCredentials().withRequestorId("reqId1").withCustomerId("custId1"));
 

--- a/mod-erm-usage-harvester-cs50/src/test/java/org/olf/erm/usage/harvester/endpoints/CS50ImplTest.java
+++ b/mod-erm-usage-harvester-cs50/src/test/java/org/olf/erm/usage/harvester/endpoints/CS50ImplTest.java
@@ -95,7 +95,7 @@ public class CS50ImplTest {
                 .withRequestorId(REQUESTOR_ID))
         .withHarvestingConfig(
             new HarvestingConfig()
-                .withReportRelease(5)
+                .withReportRelease("5")
                 .withSushiConfig(
                     new SushiConfig()
                         .withServiceUrl("http://localhost:" + wmRule.port() + "/sushi")

--- a/mod-erm-usage-harvester-nss/src/test/resources/__files/usage-data-provider.json
+++ b/mod-erm-usage-harvester-nss/src/test/resources/__files/usage-data-provider.json
@@ -8,7 +8,7 @@
       "id": "54e8d70e-6ffe-4f1b-a3b0-534e95287680",
       "vendorCode": "Nature"
     },
-    "reportRelease": 4,
+    "reportRelease": "4",
     "requestedReports": [
       "JR1",
       "TR1"

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <vertx.version>4.5.8</vertx.version>
     <aspect.version>1.9.21.1</aspect.version>
     <aspectj-maven-plugin.version>1.14</aspectj-maven-plugin.version>
-    <erm.usage.version>4.7.0</erm.usage.version>
+    <erm.usage.version>5.0.0-SNAPSHOT</erm.usage.version>
     <erm.usage.counter.version>4.1.0</erm.usage.counter.version>
     <configurations.version>5.10.0</configurations.version>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUSHARV-111

Updates to interface `usage-data-providers 3.0`.

Major version has already been increased.

Merge needs to be coordinated with:
- https://github.com/folio-org/mod-erm-usage/pull/181