### PR TITLE
[MODEUSHARV-125] Add missing interface dependencies to module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -174,6 +174,12 @@
       "version": "7.0"
     }
   ],
+  "optional": [
+    {
+      "id": "configuration",
+      "version": "2.0"
+    }
+  ],
   "permissionSets": [
     {
       "permissionName": "ermusageharvester.start-all.get",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUSHARV-125

* Adds `configuration` interface as optional