### PR TITLE
[MODEUSHARV-128] Add missing 'okapi' interface to Module Descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -178,6 +178,10 @@
     {
       "id": "configuration",
       "version": "2.0"
+    },
+    {
+      "id": "okapi",
+      "version": "1.9"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUSHARV-128
* Adds `okapi 1.9` interface as optional