### PR TITLE
Add JSON schemas, typed response, and new SPI methods for /erm-usage-harvester/impl endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "erm-usage-harvester",
-      "version": "2.0",
+      "version": "2.1",
       "handlers": [
         {
           "methods": [

--- a/mod-erm-usage-harvester-core/src/main/java/org/folio/rest/impl/ErmUsageHarvesterAPI.java
+++ b/mod-erm-usage-harvester-core/src/main/java/org/folio/rest/impl/ErmUsageHarvesterAPI.java
@@ -14,7 +14,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClient;
 import java.time.Instant;
@@ -30,6 +29,8 @@ import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.jaxrs.model.JobInfo;
 import org.folio.rest.jaxrs.model.JobInfo.Result;
 import org.folio.rest.jaxrs.model.JobInfos;
+import org.folio.rest.jaxrs.model.ServiceImplementation;
+import org.folio.rest.jaxrs.model.ServiceImplementations;
 import org.folio.rest.jaxrs.resource.ErmUsageHarvester;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
@@ -118,16 +119,17 @@ public class ErmUsageHarvesterAPI implements ErmUsageHarvester {
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
     try {
-      List<JsonObject> collect =
+      List<ServiceImplementation> implementations =
           ServiceEndpoint.getAvailableProviders().stream()
               .filter(
                   provider ->
                       Strings.isNullOrEmpty(aggregator)
                           || provider.isAggregator().equals(Boolean.valueOf(aggregator)))
               .sorted(Comparator.comparing(ServiceEndpointProvider::getServiceName))
-              .map(ServiceEndpointProvider::toJson)
+              .map(ErmUsageHarvesterAPI::toServiceImplementation)
               .toList();
-      String result = new JsonObject().put("implementations", new JsonArray(collect)).toString();
+      ServiceImplementations result =
+          new ServiceImplementations().withImplementations(implementations);
       asyncResultHandler.handle(
           succeededFuture(GetErmUsageHarvesterImplResponse.respond200WithApplicationJson(result)));
     } catch (Exception e) {
@@ -135,6 +137,28 @@ public class ErmUsageHarvesterAPI implements ErmUsageHarvester {
           succeededFuture(
               GetErmUsageHarvesterImplResponse.respond500WithTextPlain(e.getMessage())));
     }
+  }
+
+  private static ServiceImplementation toServiceImplementation(ServiceEndpointProvider provider) {
+    ServiceImplementation impl =
+        new ServiceImplementation()
+            .withName(provider.getServiceName())
+            .withDescription(provider.getServiceDescription())
+            .withType(provider.getServiceType())
+            .withIsAggregator(provider.isAggregator());
+    if (!provider.getConfigurationParameters().isEmpty()) {
+      impl.setConfigurationParameters(provider.getConfigurationParameters());
+    }
+    if (provider.getReportRelease() != null) {
+      impl.setReportRelease(provider.getReportRelease());
+    }
+    if (!provider.getSupportedReports().isEmpty()) {
+      impl.setSupportedReports(provider.getSupportedReports().stream().sorted().toList());
+    }
+    if (provider.isDefault()) {
+      impl.setIsDefault(true);
+    }
+    return impl;
   }
 
   private Criteria createTimestampCriteria(Number timestamp) {

--- a/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/endpoints/Test1Provider.java
+++ b/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/endpoints/Test1Provider.java
@@ -22,6 +22,31 @@ public class Test1Provider implements ServiceEndpointProvider {
   }
 
   @Override
+  public String getServiceDescription() {
+    return "Test1 description";
+  }
+
+  @Override
+  public String getReportRelease() {
+    return "5";
+  }
+
+  @Override
+  public List<String> getSupportedReports() {
+    return List.of("TR", "DR");
+  }
+
+  @Override
+  public boolean isDefault() {
+    return true;
+  }
+
+  @Override
+  public List<String> getConfigurationParameters() {
+    return List.of("param1", "param2");
+  }
+
+  @Override
   public ServiceEndpoint create(UsageDataProvider provider, AggregatorSetting aggregator) {
     return (report, beginDate, endDate) -> {
       List<CounterReport> resultList =

--- a/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/rest/impl/ErmUsageHarvesterAPITest.java
+++ b/mod-erm-usage-harvester-core/src/test/java/org/olf/erm/usage/harvester/rest/impl/ErmUsageHarvesterAPITest.java
@@ -2,12 +2,12 @@ package org.olf.erm.usage.harvester.rest.impl;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 
 import io.restassured.RestAssured;
@@ -18,7 +18,10 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.List;
 import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.jaxrs.model.ServiceImplementation;
+import org.folio.rest.jaxrs.model.ServiceImplementations;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -106,14 +109,34 @@ public class ErmUsageHarvesterAPITest {
 
   @Test
   public void getImplementations() {
-    given()
-        .header(TENANT_HEADER)
-        .when()
-        .get("/impl")
-        .then()
-        .statusCode(200)
-        .body("implementations.size()", greaterThanOrEqualTo(2))
-        .body("implementations.type", hasItems("test1", "test2"));
+    ServiceImplementations result =
+        given()
+            .header(TENANT_HEADER)
+            .when()
+            .get("/impl")
+            .then()
+            .statusCode(200)
+            .extract()
+            .as(ServiceImplementations.class);
+
+    assertThat(result.getImplementations())
+        .hasSizeGreaterThanOrEqualTo(2)
+        .usingRecursiveFieldByFieldElementComparator()
+        .containsOnlyOnceElementsOf(
+            List.of(
+                new ServiceImplementation()
+                    .withType("test1")
+                    .withName("test1")
+                    .withDescription("Test1 description")
+                    .withIsAggregator(false)
+                    .withReportRelease("5")
+                    .withSupportedReports(List.of("DR", "TR"))
+                    .withIsDefault(true)
+                    .withConfigurationParameters(List.of("param1", "param2")),
+                new ServiceImplementation()
+                    .withType("test2")
+                    .withName("test2")
+                    .withIsAggregator(true)));
   }
 
   @Test

--- a/mod-erm-usage-harvester-cs41/src/main/java/org/olf/erm/usage/harvester/endpoints/CS41Provider.java
+++ b/mod-erm-usage-harvester-cs41/src/main/java/org/olf/erm/usage/harvester/endpoints/CS41Provider.java
@@ -1,5 +1,6 @@
 package org.olf.erm.usage.harvester.endpoints;
 
+import java.util.List;
 import org.folio.rest.jaxrs.model.AggregatorSetting;
 import org.folio.rest.jaxrs.model.UsageDataProvider;
 
@@ -23,6 +24,39 @@ public class CS41Provider implements ServiceEndpointProvider {
   @Override
   public Boolean isAggregator() {
     return false;
+  }
+
+  @Override
+  public String getReportRelease() {
+    return "4";
+  }
+
+  @Override
+  public List<String> getSupportedReports() {
+    return List.of(
+        "BR1",
+        "BR2",
+        "BR3",
+        "BR4",
+        "BR5",
+        "BR7",
+        "DB1",
+        "DB2",
+        "JR1",
+        "JR1 GOA",
+        "JR1a",
+        "JR2",
+        "JR3",
+        "JR3 Mobile",
+        "JR4",
+        "JR5",
+        "MR1",
+        "MR1 Mobile",
+        "PR1",
+        "TR1",
+        "TR2",
+        "TR3",
+        "TR3 Mobile");
   }
 
   @Override

--- a/mod-erm-usage-harvester-cs50/src/main/java/org/olf/erm/usage/harvester/endpoints/CS50Provider.java
+++ b/mod-erm-usage-harvester-cs50/src/main/java/org/olf/erm/usage/harvester/endpoints/CS50Provider.java
@@ -1,5 +1,6 @@
 package org.olf.erm.usage.harvester.endpoints;
 
+import java.util.List;
 import org.folio.rest.jaxrs.model.AggregatorSetting;
 import org.folio.rest.jaxrs.model.UsageDataProvider;
 
@@ -18,6 +19,16 @@ public class CS50Provider implements ServiceEndpointProvider {
   @Override
   public String getServiceDescription() {
     return "Implementation for Counter/Sushi 5";
+  }
+
+  @Override
+  public String getReportRelease() {
+    return "5";
+  }
+
+  @Override
+  public List<String> getSupportedReports() {
+    return List.of("DR", "IR", "PR", "TR");
   }
 
   @Override

--- a/mod-erm-usage-harvester-cs51/src/main/java/org/olf/erm/usage/harvester/endpoints/CS51Provider.java
+++ b/mod-erm-usage-harvester-cs51/src/main/java/org/olf/erm/usage/harvester/endpoints/CS51Provider.java
@@ -1,5 +1,6 @@
 package org.olf.erm.usage.harvester.endpoints;
 
+import java.util.List;
 import org.folio.rest.jaxrs.model.AggregatorSetting;
 import org.folio.rest.jaxrs.model.UsageDataProvider;
 
@@ -18,6 +19,21 @@ public class CS51Provider implements ServiceEndpointProvider {
   @Override
   public String getServiceDescription() {
     return "Implementation for Counter/Sushi 5.1";
+  }
+
+  @Override
+  public String getReportRelease() {
+    return "5.1";
+  }
+
+  @Override
+  public List<String> getSupportedReports() {
+    return List.of("DR", "IR", "PR", "TR");
+  }
+
+  @Override
+  public boolean isDefault() {
+    return true;
   }
 
   @Override

--- a/mod-erm-usage-harvester-nss/src/main/java/org/olf/erm/usage/harvester/endpoints/NSSProvider.java
+++ b/mod-erm-usage-harvester-nss/src/main/java/org/olf/erm/usage/harvester/endpoints/NSSProvider.java
@@ -1,6 +1,5 @@
 package org.olf.erm.usage.harvester.endpoints;
 
-import java.util.Arrays;
 import java.util.List;
 import org.folio.rest.jaxrs.model.AggregatorSetting;
 import org.folio.rest.jaxrs.model.UsageDataProvider;
@@ -29,7 +28,40 @@ public class NSSProvider implements ServiceEndpointProvider {
 
   @Override
   public List<String> getConfigurationParameters() {
-    return Arrays.asList("apiKey", "requestorId", "customerId", "reportRelease");
+    return List.of("apiKey", "requestorId", "customerId");
+  }
+
+  @Override
+  public String getReportRelease() {
+    return "4";
+  }
+
+  @Override
+  public List<String> getSupportedReports() {
+    return List.of(
+        "BR1",
+        "BR2",
+        "BR3",
+        "BR4",
+        "BR5",
+        "BR7",
+        "DB1",
+        "DB2",
+        "JR1",
+        "JR1 GOA",
+        "JR1a",
+        "JR2",
+        "JR3",
+        "JR3 Mobile",
+        "JR4",
+        "JR5",
+        "MR1",
+        "MR1 Mobile",
+        "PR1",
+        "TR1",
+        "TR2",
+        "TR3",
+        "TR3 Mobile");
   }
 
   @Override

--- a/mod-erm-usage-harvester-spi/src/main/java/org/olf/erm/usage/harvester/endpoints/ServiceEndpointProvider.java
+++ b/mod-erm-usage-harvester-spi/src/main/java/org/olf/erm/usage/harvester/endpoints/ServiceEndpointProvider.java
@@ -1,6 +1,5 @@
 package org.olf.erm.usage.harvester.endpoints;
 
-import io.vertx.core.json.JsonObject;
 import java.util.Collections;
 import java.util.List;
 import org.folio.rest.jaxrs.model.AggregatorSetting;
@@ -28,7 +27,7 @@ public interface ServiceEndpointProvider {
   String getServiceName();
 
   default String getServiceDescription() {
-    return "";
+    return null;
   }
 
   default Boolean isAggregator() {
@@ -41,15 +40,15 @@ public interface ServiceEndpointProvider {
     return Collections.emptyList();
   }
 
-  default JsonObject toJson() {
-    JsonObject result =
-        new JsonObject()
-            .put("name", getServiceName())
-            .put("description", getServiceDescription())
-            .put("type", getServiceType())
-            .put("isAggregator", isAggregator());
-    if (!getConfigurationParameters().isEmpty())
-      result.put("configurationParameters", getConfigurationParameters());
-    return result;
+  default String getReportRelease() {
+    return null;
+  }
+
+  default List<String> getSupportedReports() {
+    return Collections.emptyList();
+  }
+
+  default boolean isDefault() {
+    return false;
   }
 }

--- a/ramls/harvester.raml
+++ b/ramls/harvester.raml
@@ -9,6 +9,7 @@ documentation:
 
 types:
   jobInfos: !include schemas/jobInfos.json
+  serviceImplementations: !include schemas/serviceImplementations.json
   errors: !include raml-util/schemas/errors.schema
 
 traits:
@@ -69,6 +70,7 @@ resourceTypes:
           description: List of available service implementations
           body:
             application/json:
+              type: serviceImplementations
         400:
           description: Bad request
           body:
@@ -103,9 +105,9 @@ resourceTypes:
           body:
             text/plain:
         500:
-            description: Internal server error
-            body:
-              text/plain:
+          description: Internal server error
+          body:
+            text/plain:
     /purgefinished:
       post:
         description: Purge finished harvesting jobs

--- a/ramls/schemas/serviceImplementation.json
+++ b/ramls/schemas/serviceImplementation.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "javaType": "org.folio.rest.jaxrs.model.ServiceImplementation",
+  "title": "Service Implementation Schema",
+  "description": "A service endpoint implementation",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "Human-readable display name",
+      "type": "string"
+    },
+    "description": {
+      "description": "Implementation description",
+      "type": "string"
+    },
+    "type": {
+      "description": "Service type identifier",
+      "type": "string"
+    },
+    "isAggregator": {
+      "description": "Whether this is an aggregator implementation",
+      "type": "boolean"
+    },
+    "isDefault": {
+      "description": "Whether this is the default implementation",
+      "type": "boolean"
+    },
+    "reportRelease": {
+      "description": "COUNTER report release version",
+      "type": "string"
+    },
+    "supportedReports": {
+      "description": "List of supported report types",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "configurationParameters": {
+      "description": "List of configuration parameter names",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "name",
+    "type",
+    "isAggregator"
+  ],
+  "additionalProperties": false
+}

--- a/ramls/schemas/serviceImplementations.json
+++ b/ramls/schemas/serviceImplementations.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of ServiceImplementation objects",
+  "type": "object",
+  "properties": {
+    "implementations": {
+      "description": "List of service implementations",
+      "type": "array",
+      "items": {
+        "$ref": "serviceImplementation.json"
+      }
+    }
+  },
+  "required": [
+    "implementations"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUSHARV-162

## Purpose

The `/erm-usage-harvester/impl` endpoint currently returns only basic metadata (name, type, isAggregator) for each service implementation. The COUNTER report release version and supported report types are hardcoded in the frontend (`ui-erm-usage`), creating tight coupling and maintenance burden. Moving this information to the backend allows the frontend to dynamically determine available report releases and types per service implementation.
## Approach

- Added `getReportRelease()`, `getSupportedReports()`, and `isDefault()` default methods to the `ServiceEndpointProvider` SPI interface; removed the `toJson()` method
- Implemented these methods in all existing providers (CS41, CS50, CS51, NSS) with their specific values
- Added JSON schemas (`serviceImplementation.json`, `serviceImplementations.json`) and updated `harvester.raml` to type the `/impl` response, replacing the previously untyped JSON construction with RMB-generated `ServiceImplementation`/`ServiceImplementations` POJOs
- Removed `reportRelease` from NSS configuration parameters since it is now a provider-level property
- Bumped `erm-usage-harvester` interface version from 2.0 to 2.1
- Updated tests to validate the new response structure including the added fields