### PR TITLE
[MODEUSHARV-167] Add regression tests for CS50 and CS51

### DIFF
--- a/mod-erm-usage-harvester-cs50/src/test/java/org/olf/erm/usage/harvester/endpoints/CS50ImplTest.java
+++ b/mod-erm-usage-harvester-cs50/src/test/java/org/olf/erm/usage/harvester/endpoints/CS50ImplTest.java
@@ -125,8 +125,8 @@ public class CS50ImplTest {
     return createStubWithBody(reportName, code, body);
   }
 
-  private String createStubWithBody(int code, String body) {
-    return createStubWithBody(REPORT, code, body);
+  private void createStubWithBody(int code, String body) {
+    createStubWithBody(REPORT, code, body);
   }
 
   private String createStubWithBody(String reportName, int code, String body) {
@@ -247,7 +247,8 @@ public class CS50ImplTest {
             context.asyncAssertSuccess(
                 list -> {
                   assertThat(list).hasSize(1);
-                  assertThat(list.get(0).getReport().getAdditionalProperties().get("Report_Items"))
+                  assertThat(
+                          list.getFirst().getReport().getAdditionalProperties().get("Report_Items"))
                       .isNotNull();
                   verifyApiCall();
                 }));
@@ -262,7 +263,8 @@ public class CS50ImplTest {
             context.asyncAssertSuccess(
                 list -> {
                   assertThat(list).hasSize(1);
-                  assertThat(list.get(0).getReport().getAdditionalProperties().get("Report_Items"))
+                  assertThat(
+                          list.getFirst().getReport().getAdditionalProperties().get("Report_Items"))
                       .isNotNull();
                   verifyApiCall();
                 }));
@@ -293,7 +295,7 @@ public class CS50ImplTest {
             context.asyncAssertSuccess(
                 list -> {
                   assertThat(list).hasSize(1);
-                  Report receivedReport = list.get(0).getReport();
+                  Report receivedReport = list.getFirst().getReport();
                   Report expectedReport = decodeReport(expectedReportStr, COUNTERTitleReport.class);
                   assertThat(receivedReport)
                       .usingRecursiveComparison()
@@ -312,7 +314,7 @@ public class CS50ImplTest {
             context.asyncAssertSuccess(
                 list -> {
                   assertThat(list).hasSize(1);
-                  Report receivedReport = list.get(0).getReport();
+                  Report receivedReport = list.getFirst().getReport();
                   Report expectedReport = decodeReport(expectedReportStr, COUNTERTitleReport.class);
                   assertThat(receivedReport)
                       .usingRecursiveComparison()
@@ -590,6 +592,34 @@ public class CS50ImplTest {
                       .hasMessageStartingWith(
                           "com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException");
                   verifyApiCall();
+                }));
+  }
+
+  @Test
+  public void testTrailingSlashRedirect(TestContext context) throws IOException {
+    var expectedBody =
+        Resources.toString(Resources.getResource("SampleReport.json"), StandardCharsets.UTF_8);
+
+    // The redirect path
+    wmRule.stubFor(
+        get(urlPathEqualTo(REPORT_PATH))
+            .willReturn(aResponse().withStatus(301).withHeader("Location", REPORT_PATH + "/")));
+
+    // The happy path
+    wmRule.stubFor(
+        get(urlPathEqualTo(REPORT_PATH + "/"))
+            .willReturn(aResponse().withStatus(200).withBody(expectedBody)));
+
+    new CS50Impl(provider)
+        .fetchReport(REPORT, BEGIN_DATE, END_DATE)
+        .onComplete(
+            context.asyncAssertSuccess(
+                list -> {
+                  assertThat(list).hasSize(1);
+                  // The URL we actually called
+                  wmRule.verify(1, getRequestedFor(urlPathEqualTo(REPORT_PATH)));
+                  // The URL we got redirected to
+                  wmRule.verify(1, getRequestedFor(urlPathEqualTo(REPORT_PATH + "/")));
                 }));
   }
 }

--- a/mod-erm-usage-harvester-cs51/src/test/java/org/olf/erm/usage/harvester/endpoints/CS51ImplTest.java
+++ b/mod-erm-usage-harvester-cs51/src/test/java/org/olf/erm/usage/harvester/endpoints/CS51ImplTest.java
@@ -187,7 +187,8 @@ class CS51ImplTest {
                                     assertThat(r)
                                         .extracting("downloadTime")
                                         .doesNotContainNull()
-                                        .allMatch(time -> time.equals(r.get(0).getDownloadTime()));
+                                        .allMatch(
+                                            time -> time.equals(r.getFirst().getDownloadTime()));
                                     assertThat(r).extracting("report").doesNotContainNull();
                                     assertThat(r).extracting("failedAttempts").containsOnlyNulls();
                                   });
@@ -441,5 +442,34 @@ class CS51ImplTest {
     } finally {
       ProxySelector.setDefault(defaultProxySelector);
     }
+  }
+
+  @Test
+  void testTrailingSlashRedirect(final VertxTestContext testContext) {
+    // The redirect path
+    serviceMock.stubFor(
+        get(urlPathEqualTo(PATH_TR))
+            .willReturn(aResponse().withStatus(301).withHeader("Location", PATH_TR + "/")));
+
+    // The happy path
+    serviceMock.stubFor(
+        get(urlPathEqualTo(PATH_TR + "/"))
+            .willReturn(aResponse().withStatus(200).withBodyFile("TR.json")));
+
+    new CS51Impl(provider)
+        .fetchReport(REPORT_TR, BEGIN_DATE, END_DATE)
+        .onComplete(
+            ar -> {
+              testContext
+                  .verify(
+                      () -> {
+                        assertThat(ar.succeeded()).isTrue();
+                        // The URL we actually called
+                        serviceMock.verify(1, getRequestedFor(urlPathEqualTo(PATH_TR)));
+                        // The URL we got redirected to
+                        serviceMock.verify(1, getRequestedFor(urlPathEqualTo(PATH_TR + "/")));
+                      })
+                  .completeNow();
+            });
   }
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEUSHARV-167

## Purpose
On master, the COUNTER 5.0 (CS50Impl) and 5.1 (CS51Impl) endpoints follow HTTP 3xx redirects correctly, but only because the underlying Vert.x WebClient defaults followRedirects to true. This behavior is inherited from a library default and is not asserted anywhere in the test suite. This ticket adds regression tests that pin the redirect-following behavior so it cannot silently regress.

## Approach
* Stubs the report path to return a 301 redirect to the trailing-slash variant (e.g. /reports/tr to /reports/tr/), preserving the query string, mirroring JSTOR.
* Stubs the redirect target to return a valid report.
* Asserts the fetch succeeds, that both the original path and the redirect target were each requested once, and that the report parses.