### PR TITLE
Run Spotless on all files and bind check goal to verify phase

### DIFF
--- a/mod-erm-usage-harvester-cs41/src/test/java/org/olf/erm/usage/harvester/endpoints/CS41ImplTest.java
+++ b/mod-erm-usage-harvester-cs41/src/test/java/org/olf/erm/usage/harvester/endpoints/CS41ImplTest.java
@@ -97,7 +97,8 @@ public class CS41ImplTest {
                         postRequestedFor(urlPathEqualTo(SUSHI_SERVICE))
                             .withRequestBody(
                                 matchingXPath(
-                                        "//ns:Requestor[ns:ID='reqId1' and ns:Name='' and ns:Email='']")
+                                        "//ns:Requestor[ns:ID='reqId1' and ns:Name='' and"
+                                            + " ns:Email='']")
                                     .withXPathNamespace(
                                         "ns", "http://www.niso.org/schemas/sushi")));
 

--- a/mod-erm-usage-harvester-cs50/src/main/java/org/olf/erm/usage/harvester/endpoints/ExtendedCounter50Client.java
+++ b/mod-erm-usage-harvester-cs50/src/main/java/org/olf/erm/usage/harvester/endpoints/ExtendedCounter50Client.java
@@ -62,7 +62,6 @@ public class ExtendedCounter50Client extends Counter50Client {
 
     String body = response.body() != null ? response.body().toString() : "";
     return failedFuture(
-        new ServiceEndpointException(
-            response.statusCode(), response.statusMessage(), body));
+        new ServiceEndpointException(response.statusCode(), response.statusMessage(), body));
   }
 }

--- a/mod-erm-usage-harvester-spi/src/main/java/org/olf/erm/usage/harvester/endpoints/TooManyRequestsException.java
+++ b/mod-erm-usage-harvester-spi/src/main/java/org/olf/erm/usage/harvester/endpoints/TooManyRequestsException.java
@@ -16,5 +16,4 @@ public class TooManyRequestsException extends RuntimeException {
   public TooManyRequestsException(String message, Throwable cause) {
     super(message, cause);
   }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,6 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <version>${spotless.version}</version>
         <configuration>
-          <ratchetFrom>origin/master</ratchetFrom>
           <java>
             <googleJavaFormat>
               <version>${google-java-format.version}</version>
@@ -231,6 +230,14 @@
             </googleJavaFormat>
           </java>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Purpose

Checking code formatting is currently a manual effort that can be missed, as `spotless:check` is not bound to any lifecycle phase and therefore not executed during a regular Maven build or in CI.

## Approach

- Remove the `ratchetFrom` setting from the Spotless plugin configuration in `pom.xml` so all files are subject to formatting checks.
- Bind the `spotless:check` goal to the `verify` phase so `mvn verify` fails on formatting violations.
- Apply `spotless:apply` to the full codebase, fixing formatting in three files (`CS41ImplTest`, `ExtendedCounter50Client`, `TooManyRequestsException`).

This mimics the setup in mod-erm-usage-counter (folio-org/mod-erm-usage-counter#101, folio-org/mod-erm-usage-counter#102).