### PR TITLE
MODEUSHARV-171: Remove version propery in RAML files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * [MODEUSHARV-167](https://folio-org.atlassian.net/browse/MODEUSHARV-167) Add regression tests asserting CS50/CS51 follow HTTP 3xx redirects
 * Run Spotless on all files and bind `check` goal to `verify` phase
 * [MODEUSHARV-170](https://folio-org.atlassian.net/browse/MODEUSHARV-170) Allow both registry domains for `Registry_Record` in COUNTER 5.1 reports
+* [MODEUSHARV-171](https://folio-org.atlassian.net/browse/MODEUSHARV-171) Remove optional `version` property from RAML files
 
 # 5.2.0
 * [MODEUSHARV-126](https://folio-org.atlassian.net/browse/MODEUSHARV-126) Migrate settings from `mod-configuration` to `mod-settings`

--- a/ramls/harvester.raml
+++ b/ramls/harvester.raml
@@ -1,6 +1,5 @@
 #%RAML 1.0
 title: mod-erm-usage-harvester API
-version: v1.3
 baseUri: http://localhost/erm-usage-harvester
 
 documentation:

--- a/ramls/periodic.raml
+++ b/ramls/periodic.raml
@@ -1,6 +1,5 @@
 #%RAML 1.0
 title: mod-erm-usage-harvester periodic API
-version: v1
 baseUri: http://localhost/erm-usage-harvester/periodic
 
 documentation:


### PR DESCRIPTION
[MODEUSHARV-171](https://folio-org.atlassian.net/browse/MODEUSHARV-171)

**Description**

In several FOLIO module repositories, the interface version declared in the `ModuleDescriptor-template.json` does not match the version declared in the corresponding RAML file(s).
Documentation accuracy — the RAML version is the source of truth for the API contract; a mismatch is confusing for anyone consulting the RAML as documentation.

- erm-usage-harvester 2.1 harvester.raml → v1.3 (/start, /impl, /jobs) + periodic.raml → v1 (/periodic)

**Approach**

Remove version propery in these RAML files:
- harvester.raml
- periodic.raml